### PR TITLE
feat: 진행 중인 프로젝트 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,20 +12,20 @@ import ProfileBusiness from './features/profile/ProfileBusiness.jsx';
 import RevenueHistory from './features/revenue/RevenueHistory.jsx';
 import ProfileArtist from './features/profile/ProfileArtist.jsx';
 import Portfolio from './features/portfolio/list/Portfolio.jsx';
-import OngoingProjects from './features/project/OngoingProjects.jsx';
-import CompletedProjects from './features/project/CompletedProjects.jsx';
+import OngoingProjects from './features/project/list/ongoing/OngoingProjects';
+import CompletedProjects from './features/project/list/completed/CompletedProjects.jsx';
 import PortfolioAdd from './features/portfolio/add/PortfolioAdd.jsx';
 import Login from './Login.jsx';
 import Signup from './Signup.jsx';
 
 const App = () => {
-  const userType = 'artist'; // artist로 변경하면 아티스트 홈으로 리다이렉트
+  const userType = 'business'; // artist로 변경하면 아티스트 홈으로 리다이렉트
 
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<Layout userType={userType} />}>
-          {userType === "business" ? (
+          {userType === 'business' ? (
             <Route index element={<Navigate to="/dashboard/ai" replace />} />
           ) : (
             <Route index element={<Navigate to="/new-project" replace />} />
@@ -52,12 +52,7 @@ const App = () => {
           <Route path="/projects/ongoing" element={<OngoingProjects />} />
 
           {/* 404 */}
-          <Route
-            path="*"
-            element={
-              <div className="p-6 text-xl">페이지를 찾을 수 없습니다</div>
-            }
-          />
+          <Route path="*" element={<div className="p-6 text-xl">페이지를 찾을 수 없습니다</div>} />
         </Route>
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />

--- a/src/components/common/badge/StatusBadge.jsx
+++ b/src/components/common/badge/StatusBadge.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function StatusBadge({status = 'pending', className = ''}) {
+  const STATUS = {
+    pending: {dot: 'bg-[#F59E0B]', text: '시안 제출 대기 중'},
+    reviewing: {dot: 'bg-[#3B82F6]', text: '피드백 대기 중'},
+    done: {dot: 'bg-[#10B981]', text: '피드백 전달 완료'},
+  };
+
+  const current = STATUS[status] ?? STATUS.pending;
+
+  return (
+    <span
+      className={[
+        'inline-flex items-center rounded-full bg-[#F1F0EF]/70',
+        'px-[10px] py-[4px] gap-[10px] font-[600] text-[14px]',
+        className,
+      ].join(' ')}
+      role="status"
+    >
+      <span className={['inline-block rounded-full w-[10px] h-[10px]', current.dot].join(' ')} />
+      <span>{current.text}</span>
+    </span>
+  );
+}

--- a/src/features/project/OngoingProjects.jsx
+++ b/src/features/project/OngoingProjects.jsx
@@ -1,3 +1,0 @@
-export default function ProjectsList() {
-  return <div>진행중인 프로젝트 페이지 입니다</div>;
-}

--- a/src/features/project/list/ongoing/ListCard.jsx
+++ b/src/features/project/list/ongoing/ListCard.jsx
@@ -1,0 +1,17 @@
+// features/project/ListCard.jsx
+import React from 'react';
+
+export default function ListCard({title, designerName, renderStatus}) {
+  return (
+    <>
+      <div className="flex flex-col gap-[10px] w-full px-[26px] py-[20px] rounded-[13px] border border-black/10">
+        <div>{renderStatus ? renderStatus() : null}</div>
+        <h4 className="text-[18px] font-[600]">{title}</h4>
+        <div className="flex gap-1">
+          <p>{designerName}</p>
+          <span className="text-black/50">디자이너</span>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/features/project/list/ongoing/OngoingProjects.jsx
+++ b/src/features/project/list/ongoing/OngoingProjects.jsx
@@ -1,0 +1,40 @@
+import React, {useState} from 'react';
+import ListCard from './ListCard';
+import StatusBadge from '@/components/common/badge/StatusBadge'; // 경로 확인: /badge/ 제거
+
+const initialProjects = [
+  {id: 1, title: '카페 로고 및 메뉴판 디자인', status: 'pending', designerId: 'u-101', designerName: 'MINJI'},
+  {
+    id: 2,
+    title: '테이크아웃 컵 & 포장 패키지 디자인',
+    status: 'reviewing',
+    designerId: 'u-102',
+    designerName: 'dawoon_',
+  },
+  {id: 3, title: 'SNS 피드용 브랜드 이미지 제작', status: 'done', designerId: 'u-103', designerName: '비단'},
+];
+
+export default function OngoingProjects() {
+  const [projects] = useState(initialProjects);
+
+  return (
+    <div className="px-[120px] py-[26px] min-w-[1000px]">
+      <div className="flex gap-[8px]">
+        <h3 className="text-[18px] font-[800]">진행 중인 프로젝트</h3>
+        <span className="font-[800] text-[18px] text-[#5F5E5B]">{projects.length}</span>
+      </div>
+
+      <div className="py-[20px] space-y-4">
+        {projects.map((project) => (
+          <ListCard
+            key={project.id}
+            title={project.title}
+            designerName={project.designerName}
+            status={project.status}
+            renderStatus={() => <StatusBadge status={project.status} />}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### 작업 내용
- 진행 중인 프로젝트 페이지 구성
  - `project/list` 폴더 생성 및 라우팅 연결
- 프로젝트 리스트 카드 컴포넌트 생성
- StatusBadge 공통 컴포넌트 생성
  - 상태 값에 따라 3종류 뱃지 렌더링