### PR TITLE
feat: 완료된 프로젝트 페이지 UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import Login from './Login.jsx';
 import Signup from './Signup.jsx';
 
 const App = () => {
-  const userType = 'business'; // artist로 변경하면 아티스트 홈으로 리다이렉트
+  const userType = 'artist'; // artist로 변경하면 아티스트 홈으로 리다이렉트
 
   return (
     <BrowserRouter>
@@ -35,18 +35,19 @@ const App = () => {
 
           <Route path="/dashboard/ai" element={<AIInput />} />
           <Route path="/dashboard/ai/result" element={<AIResult />} />
-          <Route path="/portfolio/detail" element={<PortfolioDetail />} />
 
           <Route path="/new-project" element={<NewProject />} />
           <Route path="/no-project" element={<NoProject />} />
-          <Route path="/portfolio" element={<Portfolio userType={userType} />} />
-          <Route path="/portfolio/add" element={<PortfolioAdd />} />
           <Route path="/profile/artist" element={<ProfileArtist />} />
           <Route path="/revenue" element={<RevenueHistory />} />
 
           <Route path="/store-management" element={<StoreManagement />} />
           <Route path="/payment" element={<PaymentHistory />} />
           <Route path="/profile/business" element={<ProfileBusiness />} />
+
+          <Route path="/portfolio/add" element={<PortfolioAdd />} />
+          <Route path="/portfolio/:id" element={<PortfolioDetail />} />
+          <Route path="/portfolio" element={<Portfolio userType={userType} />} />
 
           <Route path="/projects/completed" element={<CompletedProjects />} />
           <Route path="/projects/ongoing" element={<OngoingProjects />} />

--- a/src/features/portfolio/detail/PortfolioDetail.jsx
+++ b/src/features/portfolio/detail/PortfolioDetail.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import BackButton from '@/components/common/buttons/BackButton';
 import {MoreHorizontal} from 'lucide-react';
 import MySwiper from '@/components/common/swiper/MySwiper';
@@ -6,10 +6,10 @@ import MySwiper from '@/components/common/swiper/MySwiper';
 import img1 from '../../../assets/samples/image1.jpg';
 import img2 from '../../../assets/samples/image2.jpg';
 
-export default function PortfolioDetail({designerId}) {
+export default function PortfolioDetail({}) {
   const images = [img1, img2, img1, img2];
 
-  const [data, setData] = useState({
+  const data = {
     title: 'Sage Petal 로고 & 명함 디자인',
     designerName: 'suum',
     categories: ['브랜딩', '그래픽'],
@@ -21,7 +21,7 @@ export default function PortfolioDetail({designerId}) {
 명함 앞면에는 로고와 대표자 정보를 간결하게 배치하고, 뒷면에는 샵의 슬로건과 핵심 키워드를 넣어 브랜드 메시지를 강화했습니다.
 
 최종 산출물은 실제 인쇄 후에도 색상과 질감이 유지될 수 있도록 고해상도 파일과 인쇄 가이드라인을 함께 제공했습니다.`,
-  });
+  };
 
   return (
     <div className="min-w-[1000px] py-[26px] px-[140px]">

--- a/src/features/portfolio/list/Portfolio.jsx
+++ b/src/features/portfolio/list/Portfolio.jsx
@@ -1,16 +1,13 @@
 import {Plus} from 'lucide-react';
-import {useNavigate, useLocation} from 'react-router-dom';
+import {useNavigate} from 'react-router-dom';
 import Card from './Card';
 import DefaultProfile from '../../../assets/images/default-profile-img.svg';
 import BackButton from '../../../components/common/buttons/BackButton';
 
 export default function Portfolio({userType}) {
   const navigate = useNavigate();
-  const location = useLocation();
 
-  const viewMode = location.state?.viewMode || 'own'; // 'own' 또는 'browse'
-  const designerId = location.state?.designerId;
-  const isBrowsingMode = userType === 'business' || viewMode === 'browse';
+  const isBrowsingMode = userType === 'business';
 
   const handleGoBack = () => {
     navigate(isBrowsingMode ? '/dashboard/ai' : -1);

--- a/src/features/project/CompletedProjects.jsx
+++ b/src/features/project/CompletedProjects.jsx
@@ -1,3 +1,0 @@
-export default function CompletedProjects() {
-  return <div>완료된 프로젝트 페이지 입니다</div>;
-}

--- a/src/features/project/list/completed/CompletedProjects.jsx
+++ b/src/features/project/list/completed/CompletedProjects.jsx
@@ -1,0 +1,26 @@
+import React, {useState} from 'react';
+import ListCard from './ListCard';
+
+const initialCompletedProjects = [
+  {id: 1, title: '감성적인 테이크아dnt 컵 디자인 제작', designerName: '이수빈'},
+  {id: 2, title: '여름 시즌 한정 메뉴판 디자인', designerName: 'jj_dream'},
+];
+
+export default function CompletedProjects() {
+  const [projects] = useState(initialCompletedProjects);
+
+  return (
+    <div className="px-[120px] py-[26px] min-w-[1000px]">
+      <div className="flex gap-[8px]">
+        <h3 className="text-[18px] font-[800]">완료된 프로젝트</h3>
+        <span className="font-[800] text-[18px] text-[#5F5E5B]">{projects.length}</span>
+      </div>
+
+      <div className="py-[20px] space-y-4">
+        {projects.map((project) => (
+          <ListCard key={project.id} title={project.title} designerName={project.designerName} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/project/list/completed/ListCard.jsx
+++ b/src/features/project/list/completed/ListCard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function CompletedListCard({title, designerName}) {
+  return (
+    <div className="flex flex-col gap-[10px] w-full px-[26px] py-[20px] rounded-[13px] border border-black/10">
+      <h4 className="text-[18px] font-[700]">{title}</h4>
+      <div className="flex gap-1">
+        <p>{designerName}</p>
+        <span className="text-black/50">디자이너</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### 작업 내용
1. 완료된 프로젝트 구현
- 완료된 프로젝트 리스트 카드 컴포넌트 구현
- 완료된 프로젝트 페이지 구현
  - 프로젝트 데이터 기반으로 카드 UI 렌더링

2. 포트폴리오 라우팅 수정
- 기존: 유저타입(business / artist)에 따라 경로 분기
- 변경: 유저타입 분기 구조는 유지하되, 포트폴리오 상세 페이지 접근 시 :id 파라미터를 활용해 포트폴리오 카드별로 상세 페이지가 동적으로 렌더링되도록 수정