### PR TITLE
feat: 내 정보 페이지 API 연동

### DIFF
--- a/src/api/auth/login.js
+++ b/src/api/auth/login.js
@@ -9,12 +9,16 @@ export const loginApi = async ({email, password}) => {
       {email, password},
       {
         baseURL: BASE_URL,
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: {'Content-Type': 'application/json'},
       }
     );
-    return res.data ?? null;
+
+    const rawAuth = res.headers?.authorization || '';
+    const token = rawAuth.replace(/^Bearer\s+/i, '');
+
+    const body = res.data ?? {};
+
+    return {...body, token};
   } catch (err) {
     if (err.response) {
       const msg = err.response.data?.message || `로그인 실패 (${err.response.status})`;

--- a/src/api/auth/login.js
+++ b/src/api/auth/login.js
@@ -16,10 +16,13 @@ export const loginApi = async ({email, password}) => {
     );
     return res.data ?? null;
   } catch (err) {
-    if (err.respons) {
-      const msg = err.respons.data?.message || `로그인 실패 (${err.response.status})`;
+    if (err.response) {
+      const msg = err.response.data?.message || `로그인 실패 (${err.response.status})`;
       throw new Error(msg);
+    } else if (err.request) {
+      throw new Error('서버에 연결할 수 없습니다');
+    } else {
+      throw new Error('요청 처리 중 오류가 발생했습니다');
     }
-    throw new Error(err.request || `서버에 연결할 수 없습니다`);
   }
 };

--- a/src/api/user/index.js
+++ b/src/api/user/index.js
@@ -1,0 +1,7 @@
+export {
+  fetchMyProfile,
+  saveDesignerProfile,
+  saveBusinessProfile,
+  uploadDesignerProfileImage,
+  uploadProfileImage,
+} from './user';

--- a/src/api/user/user.js
+++ b/src/api/user/user.js
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import {useStore} from '@/store/useStore';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const userApi = axios.create({
+  baseURL: BASE_URL,
+  timeout: 10000,
+});
+
+userApi.interceptors.request.use((config) => {
+  try {
+    const {token} = useStore.getState();
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  } catch {}
+  return config;
+});
+
+const normalizeProfileFromServer = (data) => {
+  if (!data || typeof data !== 'object') return data;
+  const nickName = data.nickName ?? data.nickname ?? '';
+  return {...data, nickName};
+};
+
+const normalizeProfileToServer = (payload) => {
+  if (!payload || typeof payload !== 'object') return payload;
+  const {nickname, ...rest} = payload;
+  const nickName = payload.nickName ?? nickname;
+  return {...rest, ...(nickName !== undefined ? {nickName} : {})};
+};
+
+export const fetchMyProfile = async () => {
+  const {data} = await userApi.get('/api/mypage/me');
+  return normalizeProfileFromServer(data);
+};
+
+export const saveDesignerProfile = async (payload) => {
+  const body = normalizeProfileToServer(payload);
+  const {data} = await userApi.post('/api/mypage/designer', body);
+  return normalizeProfileFromServer(data);
+};
+
+export const saveBusinessProfile = async (payload) => {
+  const body = normalizeProfileToServer(payload);
+  const {data} = await userApi.post('/api/mypage/business-owner', body);
+  return normalizeProfileFromServer(data);
+};
+
+export const uploadDesignerProfileImage = async (formData) => {
+  const {data} = await userApi.post('/api/mypage/designer/profile-image', formData);
+  return data;
+};
+
+export const uploadProfileImage = async (file, userType) => {
+  const formData = new FormData();
+  formData.append('profileImage', file);
+  const endpoint =
+    (userType || '').toUpperCase() === 'BUSINESS'
+      ? '/api/mypage/business-owner/profile-image'
+      : '/api/mypage/designer/profile-image';
+  const {data} = await userApi.post(endpoint, formData);
+  return data;
+};

--- a/src/components/common/form/Dropdown.jsx
+++ b/src/components/common/form/Dropdown.jsx
@@ -1,9 +1,20 @@
 import {useState} from 'react';
 import {X, ChevronDown, ChevronUp} from 'lucide-react';
+import {useMemo} from 'react';
 
 export default function Dropdown({options = [], selectedValues = [], onChange, placeholder}) {
   const maxSelections = 3;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const normalizedOptions = useMemo(
+    () => options.map((opt) => (typeof opt === 'string' ? {label: opt, value: opt} : opt)),
+    [options]
+  );
+
+  const valueToLabel = useMemo(
+    () => Object.fromEntries(normalizedOptions.map((o) => [o.value, o.label])),
+    [normalizedOptions]
+  );
 
   const handleOptionToggle = (option) => {
     const isAlreadySelected = selectedValues.includes(option);
@@ -23,23 +34,25 @@ export default function Dropdown({options = [], selectedValues = [], onChange, p
       {/* 선택된 항목들 */}
       {selectedValues.length > 0 && (
         <div className="flex flex-wrap gap-[10px] mb-[8px]">
-          {selectedValues.map((item) => (
-            <div
-              key={item}
-              className="inline-flex items-center gap-[8px] px-[12px] py-[8px] rounded-[22px] border border-black/20"
-            >
-              <span className="whitespace-nowrap text-[16px] font-[600]">{item}</span>
-              <button
-                type="button"
-                onClick={() => handleOptionToggle(item)}
-                className=""
-                aria-label={`${item} 제거`}
-                title="제거"
+          {selectedValues.map((value) => {
+            const label = valueToLabel[value] ?? value;
+            return (
+              <div
+                key={value}
+                className="inline-flex items-center gap-[8px] px-[12px] py-[8px] rounded-[22px] border border-black/20"
               >
-                <X className="w-[14px] h-[14px]" />
-              </button>
-            </div>
-          ))}
+                <span className="whitespace-nowrap text-[16px] font-[600]">{label}</span>
+                <button
+                  type="button"
+                  onClick={() => handleOptionToggle(value)}
+                  aria-label={`${label} 제거`}
+                  title="제거"
+                >
+                  <X className="w-[14px] h-[14px]" />
+                </button>
+              </div>
+            );
+          })}
         </div>
       )}
 
@@ -57,24 +70,24 @@ export default function Dropdown({options = [], selectedValues = [], onChange, p
         </button>
 
         {isDropdownOpen && (
-          <div className="absolute w-full bg-white rounded-[12px] shadow-[0_4px_20px_0_rgba(0,0,0,0.1)] z-10">
-            {options.map((option) => {
-              const isSelected = selectedValues.includes(option);
+          <div className="absolute w-full bg-white rounded-[12px] shadow-[0_4px_20px_0_rgba(0,0,0,0.1)] z-10 max-h-[240px] overflow-auto">
+            {normalizedOptions.map((opt) => {
+              const isSelected = selectedValues.includes(opt.value);
               const isMaxed = !isSelected && selectedValues.length >= maxSelections;
 
               return (
                 <button
-                  key={option}
+                  key={opt.value}
                   type="button"
                   onClick={() => {
-                    if (!isMaxed) handleOptionToggle(option);
+                    if (!isMaxed) handleOptionToggle(opt.value);
                   }}
                   className={`w-full text-left px-[16px] py-[12px] ${isSelected ? 'bg-gray-100' : ''} ${
                     isMaxed ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-50'
                   }`}
                   disabled={isMaxed}
                 >
-                  {option}
+                  {opt.label}
                 </button>
               );
             })}

--- a/src/features/auth/Login.jsx
+++ b/src/features/auth/Login.jsx
@@ -25,6 +25,9 @@ function Login() {
   const [password, setPassword] = useState('');
   const [passwordVisible, setPasswordVisible] = useState(false);
 
+  const setUserType = useStore((s) => s.setUserType);
+  const setToken = useStore((s) => s.setToken);
+
   // 오류 상태 관리
   const [errors, setErrors] = useState({
     email: '',
@@ -76,7 +79,7 @@ function Login() {
   };
 
   // 폼 제출 핸들러
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
 
     // 모든 필드 유효성 검사 (제출 시에는 빈 값도 검사)
@@ -91,20 +94,26 @@ function Login() {
     // [수정] formValid로 최종 차단
     if (!(formValid && !emailError && !passwordError)) return;
 
-    loginApi({email, password})
-      .then((res) => {
-        const mappedType = toFrontendUserType(res?.userType);
+    try {
+      // 로그인 요청 → 응답 헤더의 authorization에서 token 추출됨
+      const res = await loginApi({email, password});
+      // res: { userId, userType, message, token }
 
-        useStore.setState({
-          userId: res?.userId ?? null,
-          userType: mappedType,
-        });
+      // [추가] 토큰 전역 저장 (필요 시 localStorage 연동은 추후)
+      if (res.token) setToken(res.token);
 
-        navigate('/', {replace: true});
-      })
-      .catch((err) => {
-        alert(err?.message || '회원가입 실패');
-      });
+      console.log('🔑 받은 토큰:', res.token);
+
+      // [수정] 백엔드 타입을 프론트 타입으로 매핑
+      const mappedType = toFrontendUserType(res?.userType);
+      setUserType(mappedType);
+
+      // [수정] 성공 후 이동
+      navigate('/', {replace: true});
+    } catch (err) {
+      // [수정] 메시지 문구: 로그인 실패로 통일
+      alert(err?.message || '로그인 실패');
+    }
   };
 
   return (

--- a/src/features/business/ai/AIResult.jsx
+++ b/src/features/business/ai/AIResult.jsx
@@ -64,13 +64,14 @@ export default function AIResult() {
         {/* AI 제안 요약 */}
         <div className="">
           <h3 className="mb-[18px] font-[600] text-[18px]">AI 제안 요약</h3>
-          <div className="flex gap-[18px]  ">
+          <div className="flex flex-col gap-[12px]">
             {summaryData.map((block, idx) => (
-              <div key={idx} className="w-[308px] bg-[#FBFAF9] px-[19px] py-[12px] rounded-[12px] ">
-                <div className="flex items-center gap-[4px] mb-[16px]">
+              <div key={idx} className="w-full bg-[#FBFAF9] px-[19px] py-[12px] rounded-[12px]">
+                <div className="flex items-center gap-[6px] mb-[12px]">
                   {block.icon}
                   <span className="text-[16px] font-semibold">{block.title}</span>
                 </div>
+
                 <ul className="list-disc list-inside space-y-[10px] tiny-marker">
                   {block.items.map((item, i) => (
                     <li key={i}>{item}</li>
@@ -84,7 +85,7 @@ export default function AIResult() {
         {/* 매칭 디자이너 */}
         <div>
           <h3 className="mb-[18px] font-[600] text-[18px]">매칭 디자이너</h3>
-          <div className="flex gap-10">
+          <div className="flex flex-wrap gap-10 justify-start md:justify-between">
             <DesignerCard />
             <DesignerCard />
           </div>

--- a/src/features/business/ai/DesignerCard.jsx
+++ b/src/features/business/ai/DesignerCard.jsx
@@ -14,25 +14,33 @@ export default function DesignerCard({designerId = 'designer123'}) {
 
   const handlePortfolioView = () => {
     navigate('/portfolio', {
-      state: {
-        viewMode: 'browse',
-        designerId: designerId,
-      },
+      state: {viewMode: 'browse', designerId},
     });
   };
   return (
     <>
-      <div className="relative flex flex-col gap-[16px] w-[471px] h-[254px] rounded-[12px] border border-black/10 px-[19px] py-[12px]">
+      <div
+        className="
+          relative flex flex-col gap-[16px]
+          flex-none shrink-0
+          rounded-[12px] border border-black/10 px-[19px] py-[12px]
+          overflow-hidden bg-white
+        "
+      >
         <div className="absolute top-[12px] right-[19px] flex items-center gap-[10px]">
           <AcceptButton hoverText="작업 의뢰서 보내기" onClick={() => setIsModalOpen(true)} />
           <RefreshButton />
         </div>
 
         <div className="flex items-center gap-[13px]">
-          <img src={DefaultProfile} alt="디자이너 프로필" className="w-[64px] h-[64px] rounded-full object-cover" />
-          <div className="flex flex-col gap-[6px]">
-            <p className="font-[600]">하진</p>
-            <p className="text-[#5F5E5B]">그래픽디자인 · 브랜딩</p>
+          <img
+            src={DefaultProfile}
+            alt="디자이너 프로필"
+            className="w-[64px] h-[64px] rounded-full object-cover bg-[#F6F5F4] flex-none shrink-0"
+          />
+          <div className="flex flex-col gap-[6px] truncate">
+            <p className="font-[600] leading-tight truncate">하진</p>
+            <p className="text-[#5F5E5B] leading-tight truncate">그래픽디자인 · 브랜딩</p>
           </div>
         </div>
         <div className="flex gap-2">
@@ -48,14 +56,14 @@ export default function DesignerCard({designerId = 'designer123'}) {
             alt="포트폴리오 샘플 1"
             width={210}
             height={110}
-            className="block w-[210px] h-[110px] rounded-[8px] object-cover bg-[#F6F5F4]"
+            className="block w-[210px] h-[110px] rounded-[8px] object-cover bg-[#F6F5F4] flex-none shrink-0"
           />
           <img
             src={SampleImg2}
             alt="포트폴리오 샘플 2"
             width={210}
             height={110}
-            className="block w-[210px] h-[110px] rounded-[8px] object-cover bg-[#F6F5F4]"
+            className="block w-[210px] h-[110px] rounded-[8px] object-cover bg-[#F6F5F4] flex-none shrink-0"
           />
         </div>
       </div>

--- a/src/features/user/ExtraFields.jsx
+++ b/src/features/user/ExtraFields.jsx
@@ -1,0 +1,89 @@
+import Dropdown from '@/components/common/form/Dropdown';
+import {CATEGORY_OPTIONS, STYLE_OPTIONS} from '@/features/user/ProfileOptions';
+import {useMemo} from 'react';
+
+export default function ExtraFields({profileData, isEditing, onFieldChange}) {
+  // value -> label 매핑
+  const CAT_V2L = useMemo(() => Object.fromEntries(CATEGORY_OPTIONS.map((o) => [o.value, o.label])), []);
+  const STY_V2L = useMemo(() => Object.fromEntries(STYLE_OPTIONS.map((o) => [o.value, o.label])), []);
+
+  return (
+    <div>
+      <div>
+        <label className="label-title">학력</label>
+        <input
+          type="text"
+          value={profileData.education || ''}
+          onChange={(e) => onFieldChange('education', e.target.value)}
+          disabled={!isEditing}
+          className={`form-input ${!isEditing ? 'bg-[#F8F7F6]' : ''}`}
+          placeholder="학교명을 입력해 주세요."
+        />
+      </div>
+
+      <div>
+        <label className="label-title">전공</label>
+        <input
+          type="text"
+          value={profileData.major || ''}
+          onChange={(e) => onFieldChange('major', e.target.value)}
+          disabled={!isEditing}
+          className={`form-input ${!isEditing ? 'bg-[#F8F7F6]' : ''}`}
+          placeholder="전공을 입력해 주세요."
+        />
+      </div>
+
+      <div>
+        <label className="label-title">전문 분야</label>
+        {isEditing ? (
+          <Dropdown
+            options={CATEGORY_OPTIONS}
+            selectedValues={profileData.designCategories || []}
+            onChange={(values) => onFieldChange('designCategories', values)}
+            placeholder="전문으로 활동하는 분야를 선택해 주세요."
+          />
+        ) : (
+          <div className="form-input bg-[#F8F7F6] min-h-[48px] flex items-center" aria-label="선택된 전문분야">
+            {profileData.designCategories?.length ? (
+              <div className="flex flex-wrap gap-[8px]">
+                {profileData.designCategories.map((v) => (
+                  <span key={v} className="inline-flex px-[12px] py-[4px] bg-[#EDECEA] rounded-[16px] text-[14px]">
+                    {CAT_V2L[v] || v}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span className="text-black/50">전문으로 활동하는 분야를 선택해 주세요. (최대 3개)</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label className="label-title">스타일</label>
+        {isEditing ? (
+          <Dropdown
+            options={STYLE_OPTIONS}
+            selectedValues={profileData.designStyles || []}
+            onChange={(values) => onFieldChange('designStyles', values)}
+            placeholder="추구하는 스타일을 선택해 주세요."
+          />
+        ) : (
+          <div className="form-input bg-[#F8F7F6] min-h-[48px] flex items-center" aria-label="선택된 스타일">
+            {profileData.designStyles?.length ? (
+              <div className="flex flex-wrap gap-[8px]">
+                {profileData.designStyles.map((v) => (
+                  <span key={v} className="inline-flex px-[12px] py-[4px] bg-[#EDECEA] rounded-[16px] text-[14px]">
+                    {STY_V2L[v] || v}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span className="text-black/50">추구하는 스타일을 선택해 주세요. (최대 3개)</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/ProfileArtist.jsx
+++ b/src/features/user/ProfileArtist.jsx
@@ -1,482 +1,121 @@
-import React, {useState} from 'react';
-import {useNavigate} from 'react-router-dom';
-import profileicon from '@/assets/membership/profile_business/icon/ProfileIcon.png';
-import changeicon from '@/assets/membership/profile_business/default/Change.png';
-import changeiconhover from '@/assets/membership/profile_business/hover/ChangeHover.png';
-import outicon from '@/assets/membership/profile_business/default/Out.png';
-import outiconhover from '@/assets/membership/profile_business/hover/OutHover.png';
-const UserProfile = () => {
-  const navigate = useNavigate();
-  const [editingFields, setEditingFields] = useState({
-    nickname: false,
-    phone: false,
-    email: false,
-    education: false,
-    major: false,
-    specialty: false,
-    designStyle: false,
-  });
-  const [formData, setFormData] = useState({
-    nickname: '마지막선물',
-    phone: '010-1234-5678',
-    email: 'abcde123@naver.com',
+import {useEffect, useState} from 'react';
+import {useProfile, useSaveDesigner, useUploadImage} from './hooks';
+import ProfileSide from './ProfileSide';
+import ProfileForm from './ProfileForm';
+import ExtraFields from './ExtraFields';
+import {CATEGORY_OPTIONS, STYLE_OPTIONS, toValueArray} from './ProfileOptions';
+
+export default function ProfileArtist() {
+  const {profile} = useProfile();
+  const {save: saveDesigner} = useSaveDesigner();
+  const {upload} = useUploadImage();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [profileData, setProfileData] = useState({
+    imageUrl: '',
+    email: '',
+    nickName: '',
+    phoneNumber: '',
     education: '',
     major: '',
-    specialty: [],
-    designStyle: '전문으로 활용하는 분야를 선택해 주세요. (최대 3개)',
-  });
-  const [originalData, setOriginalData] = useState({
-    nickname: '마지막선물',
-    phone: '010-1234-5678',
-    email: 'abcde123@naver.com',
-    education: '',
-    major: '',
-    specialty: [],
-    designStyle: '전문으로 활용하는 분야를 선택해 주세요. (최대 3개)',
+    designCategories: [],
+    designStyles: [],
   });
 
-  const [isSpecialtyDropdownOpen, setIsSpecialtyDropdownOpen] = useState(false);
-
-  const specialtyOptions = [
-    '로고 디자인',
-    '브랜드 디자인',
-    '굿즈 디자인',
-    '포스터·전단지 디자인',
-    '배너·광고 디자인',
-    '패키지 디자인',
-    '명함·카드·인쇄물 디자인',
-  ];
-
-  const handleEdit = (field) => {
-    if (field === 'education' || field === 'major') {
-      setOriginalData((prev) => ({
+  useEffect(() => {
+    if (profile) {
+      setProfileData((prev) => ({
         ...prev,
-        education: formData.education,
-        major: formData.major,
-      }));
-      setEditingFields((prev) => ({...prev, education: true, major: true}));
-    } else {
-      setOriginalData((prev) => ({...prev, [field]: formData[field]}));
-      setEditingFields((prev) => ({...prev, [field]: true}));
-    }
-  };
-
-  const handleSave = (field) => {
-    if (field === 'education' || field === 'major') {
-      setEditingFields((prev) => ({...prev, education: false, major: false}));
-      console.log('학력·전공 저장된 데이터:', {
-        education: formData.education,
-        major: formData.major,
-      });
-    } else {
-      setEditingFields((prev) => ({...prev, [field]: false}));
-      console.log(`${field} 저장된 데이터:`, formData[field]);
-    }
-  };
-
-  const handleCancel = (field) => {
-    if (field === 'education' || field === 'major') {
-      setFormData((prev) => ({
-        ...prev,
-        education: originalData.education,
-        major: originalData.major,
-      }));
-      setEditingFields((prev) => ({...prev, education: false, major: false}));
-    } else {
-      setFormData((prev) => ({...prev, [field]: originalData[field]}));
-      setEditingFields((prev) => ({...prev, [field]: false}));
-    }
-  };
-
-  const handleInputChange = (field, value) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
-  };
-
-  const handleSpecialtySelect = (option) => {
-    if (formData.specialty.length < 3 && !formData.specialty.includes(option)) {
-      setFormData((prev) => ({
-        ...prev,
-        specialty: [...prev.specialty, option],
+        imageUrl: profile.imageUrl ?? '',
+        email: profile.email ?? '',
+        nickName: profile.nickName ?? profile.nickname ?? '',
+        phoneNumber: profile.phoneNumber ?? '',
+        education: profile.education ?? '',
+        major: profile.major ?? '',
+        designCategories: toValueArray(profile.designCategories ?? [], CATEGORY_OPTIONS),
+        designStyles: toValueArray(profile.designStyles ?? [], STYLE_OPTIONS),
       }));
     }
-    setIsSpecialtyDropdownOpen(false);
+  }, [profile]);
+
+  const handleEdit = () => setIsEditing(true);
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    if (profile) {
+      setProfileData((prev) => ({
+        ...prev,
+        imageUrl: profile.imageUrl ?? '',
+        email: profile.email ?? '',
+        nickName: profile.nickName ?? profile.nickname ?? '',
+        phoneNumber: profile.phoneNumber ?? '',
+        education: profile.education ?? '',
+        major: profile.major ?? '',
+        designCategories: toValueArray(profile.designCategories ?? [], CATEGORY_OPTIONS),
+        designStyles: toValueArray(profile.designStyles ?? [], STYLE_OPTIONS),
+      }));
+    }
   };
 
-  const handleSpecialtyRemove = (optionToRemove) => {
-    setFormData((prev) => ({
-      ...prev,
-      specialty: prev.specialty.filter((item) => item !== optionToRemove),
-    }));
+  const handleSave = async () => {
+    const {email, nickname, ...rest} = profileData;
+
+    const payload = {
+      ...rest,
+      designCategories: toValueArray(rest.designCategories, CATEGORY_OPTIONS),
+      designStyles: toValueArray(rest.designStyles, STYLE_OPTIONS),
+    };
+
+    await saveDesigner(payload);
+    setIsEditing(false);
+  };
+
+  const handleImageUpload = async (file) => {
+    const res = await upload(file);
+    if (res?.profileImageUrl) {
+      setProfileData((p) => ({...p, imageUrl: res.profileImageUrl}));
+    }
+  };
+
+  const updateField = (field, value) => {
+    if (field === 'email') return;
+    setProfileData((p) => ({...p, [field]: value}));
   };
 
   return (
-    <div className="ml-64 p-8 min-h-screen">
-      <div className="bg-white p-8 rounded-xl shadow-sm max-w-4xl">
-        <div className="mb-8">
-          <h2 className="text-2xl font-semibold text-gray-900">내 정보</h2>
+    <div className="min-w-[1000px] px-[140px] py-[26px]">
+      <div className="flex justify-between mb-[32px]">
+        <h3 className="text-[18px] font-[600]">내 정보</h3>
+        <div className="flex gap-[12px]">
+          {!isEditing ? (
+            <button onClick={handleEdit} className="text-[#4B83E3]">
+              수정
+            </button>
+          ) : (
+            <>
+              <button onClick={handleCancel} className="text-[#4B83E3]">
+                취소
+              </button>
+              <button onClick={handleSave} className="text-[#4B83E3]">
+                저장
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-[52px]">
+        {/* 프로필 이미지 영역 */}
+        <div className="flex-shrink-0">
+          <ProfileSide profileImage={profileData.imageUrl} onImageUpload={handleImageUpload} isEditing={isEditing} />
         </div>
 
-        <div className="flex gap-16">
-          {/* 프로필 이미지 섹션 */}
-          <div className="flex flex-col items-center">
-            <div className="mb-4">
-              <img src={profileicon} alt="프로필" className="w-24 h-24 rounded-full" />
-            </div>
-
-            <div className="flex flex-col items-center gap-3">
-              <button className="group">
-                <img src={changeicon} alt="프로필 변경" className="w-20 h-8 group-hover:hidden" />
-                <img src={changeiconhover} alt="프로필 변경" className="w-20 h-8 hidden group-hover:block" />
-              </button>
-              <button className="group">
-                <img src={outicon} alt="회원탈퇴" className="w-12 h-5 group-hover:hidden" />
-                <img src={outiconhover} alt="회원탈퇴" className="w-12 h-5 hidden group-hover:block" />
-              </button>
-            </div>
-          </div>
-
-          {/* 사용자 정보 폼 */}
-          <div className="flex-1 max-w-2xl">
-            {/* 닉네임 */}
-            <div className="mb-8">
-              <div className="flex justify-between items-center mb-3">
-                <label className="block text-gray-900 text-base font-semibold">닉네임</label>
-                {!editingFields.nickname ? (
-                  <button
-                    onClick={() => handleEdit('nickname')}
-                    className="text-blue-600 text-sm font-medium hover:underline"
-                  >
-                    수정
-                  </button>
-                ) : (
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => handleSave('nickname')}
-                      className="text-blue-600 text-sm font-medium hover:underline"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => handleCancel('nickname')}
-                      className="text-gray-600 text-sm font-medium hover:underline"
-                    >
-                      취소
-                    </button>
-                  </div>
-                )}
-              </div>
-              <input
-                type="text"
-                value={formData.nickname}
-                onChange={(e) => handleInputChange('nickname', e.target.value)}
-                readOnly={!editingFields.nickname}
-                className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base ${
-                  !editingFields.nickname
-                    ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                    : 'bg-white text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-200'
-                }`}
-              />
-            </div>
-
-            {/* 전화번호 */}
-            <div className="mb-8">
-              <div className="flex justify-between items-center mb-3">
-                <label className="block text-gray-900 text-base font-semibold">전화번호</label>
-                {!editingFields.phone ? (
-                  <button
-                    onClick={() => handleEdit('phone')}
-                    className="text-blue-600 text-sm font-medium hover:underline"
-                  >
-                    수정
-                  </button>
-                ) : (
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => handleSave('phone')}
-                      className="text-blue-600 text-sm font-medium hover:underline"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => handleCancel('phone')}
-                      className="text-gray-600 text-sm font-medium hover:underline"
-                    >
-                      취소
-                    </button>
-                  </div>
-                )}
-              </div>
-              <input
-                type="text"
-                value={formData.phone}
-                onChange={(e) => handleInputChange('phone', e.target.value)}
-                readOnly={!editingFields.phone}
-                className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base ${
-                  !editingFields.phone
-                    ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                    : 'bg-white text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-200'
-                }`}
-              />
-            </div>
-
-            {/* 이메일 */}
-            <div className="mb-8">
-              <div className="flex justify-between items-center mb-3">
-                <label className="block text-gray-900 text-base font-semibold">이메일</label>
-                {!editingFields.email ? (
-                  <button
-                    onClick={() => handleEdit('email')}
-                    className="text-blue-600 text-sm font-medium hover:underline"
-                  >
-                    수정
-                  </button>
-                ) : (
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => handleSave('email')}
-                      className="text-blue-600 text-sm font-medium hover:underline"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => handleCancel('email')}
-                      className="text-gray-600 text-sm font-medium hover:underline"
-                    >
-                      취소
-                    </button>
-                  </div>
-                )}
-              </div>
-              <input
-                type="email"
-                value={formData.email}
-                onChange={(e) => handleInputChange('email', e.target.value)}
-                readOnly={!editingFields.email}
-                className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base ${
-                  !editingFields.email
-                    ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                    : 'bg-white text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-200'
-                }`}
-              />
-            </div>
-
-            {/* 학력 · 전공 */}
-            <div className="mb-8">
-              <div className="flex justify-between items-center mb-3">
-                <label className="block text-gray-900 text-base font-semibold">학력 · 전공</label>
-                {!editingFields.education && !editingFields.major ? (
-                  <button
-                    onClick={() => handleEdit('education')}
-                    className="text-blue-600 text-sm font-medium hover:underline"
-                  >
-                    수정
-                  </button>
-                ) : (
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => handleSave('education')}
-                      className="text-blue-600 text-sm font-medium hover:underline"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => handleCancel('education')}
-                      className="text-gray-600 text-sm font-medium hover:underline"
-                    >
-                      취소
-                    </button>
-                  </div>
-                )}
-              </div>
-              <div className="space-y-3">
-                <input
-                  type="text"
-                  value={formData.education}
-                  onChange={(e) => handleInputChange('education', e.target.value)}
-                  readOnly={!editingFields.education}
-                  placeholder="학교명을 입력해 주세요."
-                  className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base ${
-                    !editingFields.education
-                      ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                      : 'bg-white text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-200'
-                  }`}
-                />
-                <input
-                  type="text"
-                  value={formData.major}
-                  onChange={(e) => handleInputChange('major', e.target.value)}
-                  readOnly={!editingFields.major}
-                  placeholder="전공을 입력해 주세요."
-                  className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base ${
-                    !editingFields.major
-                      ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                      : 'bg-white text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-200'
-                  }`}
-                />
-              </div>
-            </div>
-
-            {/* 전문 분야 - 멀티 셀렉트 드롭다운 */}
-            <div className="mb-8">
-              <div className="flex justify-between items-center mb-3">
-                <label className="block text-gray-900 text-base font-semibold">전문 분야</label>
-                {!editingFields.specialty ? (
-                  <button
-                    onClick={() => handleEdit('specialty')}
-                    className="text-blue-600 text-sm font-medium hover:underline"
-                  >
-                    수정
-                  </button>
-                ) : (
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => handleSave('specialty')}
-                      className="text-blue-600 text-sm font-medium hover:underline"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => handleCancel('specialty')}
-                      className="text-gray-600 text-sm font-medium hover:underline"
-                    >
-                      취소
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              {/* 선택된 태그들 표시 */}
-              {formData.specialty.length > 0 && (
-                <div className="mb-3 flex flex-wrap gap-2">
-                  {formData.specialty.map((item, index) => (
-                    <span
-                      key={index}
-                      className="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-gray-100 text-gray-800 border border-gray-300"
-                    >
-                      {item}
-                      {editingFields.specialty && (
-                        <button
-                          type="button"
-                          onClick={() => handleSpecialtyRemove(item)}
-                          className="ml-2 text-gray-500 hover:text-gray-700"
-                        >
-                          ×
-                        </button>
-                      )}
-                    </span>
-                  ))}
-                </div>
-              )}
-
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => editingFields.specialty && setIsSpecialtyDropdownOpen(!isSpecialtyDropdownOpen)}
-                  disabled={!editingFields.specialty}
-                  className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base text-left flex justify-between items-center ${
-                    !editingFields.specialty
-                      ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                      : 'bg-white text-gray-900 hover:bg-gray-50'
-                  }`}
-                >
-                  <span className={formData.specialty.length === 0 ? 'text-gray-500' : 'text-gray-900'}>
-                    전문으로 활용하는 분야를 선택해 주세요. (최대 3개)
-                  </span>
-                  <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                </button>
-
-                {/* 드롭다운 메뉴 */}
-                {isSpecialtyDropdownOpen && editingFields.specialty && (
-                  <div className="absolute top-full left-0 right-0 mt-2 bg-white border border-gray-300 rounded-xl shadow-lg z-10 max-h-64 overflow-y-auto">
-                    {specialtyOptions.map((option) => (
-                      <button
-                        key={option}
-                        type="button"
-                        onClick={() => handleSpecialtySelect(option)}
-                        disabled={formData.specialty.includes(option) || formData.specialty.length >= 3}
-                        className={`w-full px-4 py-3 text-left hover:bg-gray-50 first:rounded-t-xl last:rounded-b-xl border-b border-gray-100 last:border-b-0 ${
-                          formData.specialty.includes(option)
-                            ? 'bg-gray-100 text-gray-900 font-semibold cursor-not-allowed'
-                            : formData.specialty.length >= 3
-                            ? 'text-gray-400 cursor-not-allowed'
-                            : 'text-gray-900'
-                        }`}
-                      >
-                        {option}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* 디자인 스타일 */}
-            <div>
-              <div className="flex justify-between items-center mb-3">
-                <label className="block text-gray-900 text-base font-semibold">디자인 스타일</label>
-                {!editingFields.designStyle ? (
-                  <button
-                    onClick={() => handleEdit('designStyle')}
-                    className="text-blue-600 text-sm font-medium hover:underline"
-                  >
-                    수정
-                  </button>
-                ) : (
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => handleSave('designStyle')}
-                      className="text-blue-600 text-sm font-medium hover:underline"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => handleCancel('designStyle')}
-                      className="text-gray-600 text-sm font-medium hover:underline"
-                    >
-                      취소
-                    </button>
-                  </div>
-                )}
-              </div>
-              <div className="relative">
-                <select
-                  value={formData.designStyle}
-                  onChange={(e) => handleInputChange('designStyle', e.target.value)}
-                  disabled={!editingFields.designStyle}
-                  className={`w-full px-4 py-3 border border-gray-300 rounded-xl text-base appearance-none ${
-                    !editingFields.designStyle
-                      ? 'bg-gray-100 text-gray-700 cursor-not-allowed'
-                      : 'bg-white text-gray-900 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-200'
-                  }`}
-                >
-                  <option value="전문으로 활용하는 분야를 선택해 주세요. (최대 3개)">
-                    전문으로 활용하는 분야를 선택해 주세요. (최대 3개)
-                  </option>
-                  <option value="미니멀 스타일">미니멀 스타일</option>
-                  <option value="빈티지 스타일">빈티지 스타일</option>
-                  <option value="모던 스타일">모던 스타일</option>
-                  <option value="클래식 스타일">클래식 스타일</option>
-                  <option value="컨템포러리 스타일">컨템포러리 스타일</option>
-                  <option value="일러스트레이션 스타일">일러스트레이션 스타일</option>
-                  <option value="타이포그래피 중심">타이포그래피 중심</option>
-                </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-gray-700">
-                  <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                    <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
-                  </svg>
-                </div>
-              </div>
-            </div>
-          </div>
+        {/* 폼 영역 */}
+        <div className="flex-1">
+          <ProfileForm profileData={profileData} isEditing={isEditing} onFieldChange={updateField} />
+          <ExtraFields profileData={profileData} isEditing={isEditing} onFieldChange={updateField} />
         </div>
       </div>
     </div>
   );
-};
-
-export default UserProfile;
+}

--- a/src/features/user/ProfileForm.jsx
+++ b/src/features/user/ProfileForm.jsx
@@ -1,0 +1,36 @@
+import '../../components/common/form/form.css';
+
+export default function ProfileForm({profileData, isEditing, onFieldChange}) {
+  return (
+    <div>
+      <div>
+        <label className="label-title">이메일</label>
+        <input type="email" value={profileData.email || ''} disabled className="form-input bg-[#F8F7F6]" readOnly />
+      </div>
+
+      <div>
+        <label className="label-title">닉네임</label>
+        <input
+          type="text"
+          value={profileData.nickName || ''}
+          onChange={(e) => onFieldChange('nickName', e.target.value)}
+          disabled={!isEditing}
+          className={`form-input ${!isEditing ? 'bg-[#F8F7F6]' : ''}`}
+          placeholder="닉네임을 입력하세요"
+        />
+      </div>
+
+      <div>
+        <label className="label-title">전화번호</label>
+        <input
+          type="tel"
+          value={profileData.phoneNumber || ''}
+          onChange={(e) => onFieldChange('phoneNumber', e.target.value)}
+          disabled={!isEditing}
+          className={`form-input ${!isEditing ? 'bg-[#F8F7F6]' : ''}`}
+          placeholder="010-1234-5648"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/ProfileOptions.js
+++ b/src/features/user/ProfileOptions.js
@@ -1,0 +1,33 @@
+export const CATEGORY_OPTIONS = [
+  {label: '로고 디자인', value: 'LOGO'},
+  {label: '브랜드 디자인', value: 'BRAND'},
+  {label: '굿즈 디자인', value: 'GOODS'},
+  {label: '포스터/전단지 디자인', value: 'POSTER_FLYER'},
+  {label: '배너/광고 디자인', value: 'BANNER_AD'},
+  {label: '패키지 디자인', value: 'PACKAGE'},
+  {label: '명함/카드/인쇄물 디자인', value: 'CARD'},
+];
+
+export const STYLE_OPTIONS = [
+  {label: '심플한', value: 'SIMPLE'},
+  {label: '따뜻한', value: 'WARM'},
+  {label: '화려한', value: 'FANCY'},
+  {label: '산뜻한', value: 'NEAT'},
+  {label: '차분한', value: 'TRANQUIL'},
+  {label: '빈티지', value: 'VINTAGE'},
+  {label: '레트로', value: 'RETRO'},
+  {label: '귀여운', value: 'CUTE'},
+  {label: '러블리', value: 'LOVELY'},
+  {label: '청량한', value: 'REFRESHING'},
+  {label: '자연스러운', value: 'NATURAL'},
+  {label: '고급스러운', value: 'LUXURIOUS'},
+  {label: '현대적인', value: 'MODERN'},
+  {label: '클래식한', value: 'CLASSIC'},
+  {label: '감성적인', value: 'EMOTIONAL'},
+];
+
+export const toValueArray = (arr, options) => {
+  if (!Array.isArray(arr)) return [];
+  const labelToValue = Object.fromEntries(options.map((o) => [o.label, o.value]));
+  return arr.map((v) => labelToValue[v] ?? v);
+};

--- a/src/features/user/ProfileSide.jsx
+++ b/src/features/user/ProfileSide.jsx
@@ -1,0 +1,62 @@
+import {useRef} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {LogOut} from 'lucide-react';
+import {useStore} from '@/store/useStore';
+import defaultProfileImg from '../../assets/images/default-profile-img.svg';
+
+export default function ProfileSide({profileImage, onImageUpload, isEditing}) {
+  const logout = useStore((s) => s.logout);
+  const navigate = useNavigate();
+  const fileInputRef = useRef(null);
+
+  const handleImageClick = () => {
+    if (isEditing && fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (file) onImageUpload(file);
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-[14px]">
+      <div
+        className={`w-[110px] h-[110px] rounded-full overflow-hidden border-2 border-gray-200 ${
+          isEditing ? 'cursor-pointer hover:opacity-80' : ''
+        }`}
+        onClick={handleImageClick}
+      >
+        <img
+          src={profileImage || defaultProfileImg} // ← imageUrl이 props로 전달됨
+          alt="프로필 이미지"
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      {isEditing && (
+        <button
+          type="button"
+          onClick={handleImageClick}
+          className="px-[12px] py-[6px] text-[15px] border border-black/30 rounded-full hover:border-black/60"
+          title="프로필 이미지 변경"
+        >
+          프로필 변경
+        </button>
+      )}
+
+      <input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileChange} className="hidden" />
+
+      <button onClick={handleLogout} className="flex items-center gap-[8px] text-black/50 hover:text-black/80">
+        <LogOut size={12} />
+        <span className="text-[12px]">로그아웃</span>
+      </button>
+    </div>
+  );
+}

--- a/src/features/user/hooks.js
+++ b/src/features/user/hooks.js
@@ -1,0 +1,61 @@
+import {useState, useEffect} from 'react';
+import {fetchMyProfile, saveDesignerProfile, saveBusinessProfile, uploadProfileImage} from '@/api/user';
+import {useStore} from '@/store/useStore';
+
+export const useProfile = () => {
+  const [profile, setProfile] = useState(null);
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchMyProfile();
+        setProfile(data);
+      } catch {}
+    })();
+  }, []);
+  return {profile};
+};
+
+export const useSaveDesigner = () => {
+  const save = async (designerData) => {
+    try {
+      const result = await saveDesignerProfile(designerData);
+      return result;
+    } catch (err) {
+      const msg = err?.response?.data?.message || err?.message || '저장 실패';
+      alert(msg);
+      return null;
+    }
+  };
+  return {save};
+};
+
+export const useSaveBusiness = () => {
+  const save = async (businessData) => {
+    try {
+      const result = await saveBusinessProfile(businessData);
+      return result;
+    } catch (err) {
+      const msg = err?.response?.data?.message || err?.message || '저장 실패';
+      alert(msg);
+      return null;
+    }
+  };
+  return {save};
+};
+
+export const useUploadImage = () => {
+  const {userType} = useStore.getState();
+
+  const upload = async (file) => {
+    if (!file) return null;
+    try {
+      const result = await uploadProfileImage(file, userType);
+      return result;
+    } catch (err) {
+      console.error('이미지 업로드 실패:', err);
+      return null;
+    }
+  };
+
+  return {upload};
+};

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -1,7 +1,17 @@
-import {create} from 'zustand';
-
 export const useStore = create((set) => ({
   userType: null,
+  token: localStorage.getItem('token') ?? null,
   setUserType: (type) => set({userType: type}),
-  logout: () => set({userType: null}),
+  setToken: (token) => {
+    if (token) {
+      localStorage.setItem('token', token);
+    } else {
+      localStorage.removeItem('token');
+    }
+    set({token});
+  },
+  logout: () => {
+    localStorage.removeItem('token');
+    set({userType: null, token: null});
+  },
 }));


### PR DESCRIPTION
### 작업 내용
- 로그인 페이지 오타 수정
- 로그인 시 토큰 발급 및 저장 기능 추가
- AI 결과 페이지 스타일 수정
  - 요약 리스트 세로 배치
  - 디자이너 카드 크기 고정
- 내 정보 페이지 컴포넌트 분리
- 내 정보 (소상공인/디자이너) 페이지 api 연동